### PR TITLE
Bugfix/fix crawler select image from replies

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -2,19 +2,7 @@ import bot = require('bbot');
 import glob from 'glob';
 import path from 'path';
 
-/** This is a workaround for Heroku to confirm web binding. */
-// @todo Remove this when bBot includes Express (next release)
-import http from 'http';
-
-process.on('uncaughtException', function (exception) {
-  console.log(exception); // to see your exception details in the console
-  // if you are on production, maybe you can send the exception details to your
-  // email as well ?
-});
-
-const handle = (req, res) => res.end('hit');
-const server = http.createServer(handle);
-server.listen(process.env.PORT || 5000);
+process.on('uncaughtException', exception => console.log(exception));
 
 /** Add your bot logic here. Removing the imported examples. */
 // glob.sync('./src/**/*.branch.js').map((file: string) => require(path.resolve(file)));

--- a/src/helpers/crawler.helper.ts
+++ b/src/helpers/crawler.helper.ts
@@ -1,11 +1,5 @@
 import puppeteer from 'puppeteer';
 
-process.on('uncaughtException', function (exception) {
-  console.log(exception); // to see your exception details in the console
-  // if you are on production, maybe you can send the exception details to your
-  // email as well ?
-});
-
 function wait(ms: number) {
   return new Promise<void>(resolve => setTimeout(() => resolve(), ms));
 }
@@ -28,17 +22,9 @@ export default async function getTwitterImageUrls(url: string): Promise<string[]
     return [];
   }
 
-  try {
-    const showNSFW_selector = "body div[data-focusable='true'] > div[dir='auto'] > span > span";
-    page.waitForSelector(showNSFW_selector, { visible: true, timeout: 10000 });
-    page.click(showNSFW_selector);
-  } catch (err) {
-    ;  // it's okay
-  }
-
   const statusId = url.replace(/^.*\//, '');
   // const xpath = `//body//a[contains(@href, '${statusId}')]/ancestor::div[position()=1]//img`;
-  const css_selector = `video[src], a[href*="${statusId}"] img[src]`;
+  const css_selector = `a[href*="/${statusId}/"] img[src]`;
   page.waitForSelector(css_selector, { visible: true, timeout: 30000 });
 
   let retry = 10;
@@ -55,11 +41,11 @@ export default async function getTwitterImageUrls(url: string): Promise<string[]
     }
 
     for (const src of media_srcs) {
-      if (src?.includes('pbs.twimg.com/media') ||
-        src?.includes('video.twimg.com/tweet_video')) {
+      if (src?.includes('pbs.twimg.com/media')) {
         valid_urls.push(src.replace(/&name=.+$/, '&name=large'));
       }
     }
+
     if (debug) {
       console.log(`retry: ${10 - retry}`, valid_urls);
     }
@@ -90,6 +76,6 @@ if (process.env.NODE_ENV !== 'production') {
   })();
 
   const img_url = 'https://twitter.com/Machiccalition/status/1374828782620565504';
-  // getTwitterImageUrls(img_url);
+  getTwitterImageUrls(img_url);
 
 }

--- a/src/helpers/crawler.helper.ts
+++ b/src/helpers/crawler.helper.ts
@@ -25,25 +25,46 @@ export default async function getTwitterImageUrls(url: string): Promise<string[]
       waitUntil: 'networkidle2'
     });
   } catch (err) {
-    throw err;
+    return [];
   }
 
-  let retry = 3;
-  const pbs_img_urls: string[] = [];
+  try {
+    const showNSFW_selector = "body div[data-focusable='true'] > div[dir='auto'] > span > span";
+    page.waitForSelector(showNSFW_selector, { visible: true, timeout: 10000 });
+    page.click(showNSFW_selector);
+  } catch (err) {
+    ;  // it's okay
+  }
+
+  const statusId = url.replace(/^.*\//, '');
+  // const xpath = `//body//a[contains(@href, '${statusId}')]/ancestor::div[position()=1]//img`;
+  const css_selector = `video[src], a[href*="${statusId}"] img[src]`;
+  page.waitForSelector(css_selector, { visible: true, timeout: 30000 });
+
+  let retry = 10;
+  const valid_urls: string[] = [];
   while (retry--) {
     // Crawl src for all <img> tags
-    const img_urls = await page.$$eval('img[src]', imgs => imgs.map(img => img.getAttribute('src')));
+    const media_srcs = await page.$$eval(css_selector, imgs => imgs.map(img => img.getAttribute('src')));
+    if (!media_srcs.length) {
+      await wait(1000);
+      if (debug) {
+        console.log(`retry: ${10 - retry}`, media_srcs);
+      }
+      continue;
+    }
 
-    for (const img_url of img_urls) {
-      if (img_url?.includes('pbs.twimg.com/media')) {
-        pbs_img_urls.push(img_url.replace(/&name=.+$/, '&name=large'));
+    for (const src of media_srcs) {
+      if (src?.includes('pbs.twimg.com/media') ||
+        src?.includes('video.twimg.com/tweet_video')) {
+        valid_urls.push(src.replace(/&name=.+$/, '&name=large'));
       }
     }
     if (debug) {
-      console.log(`retry: ${3 - retry}`, pbs_img_urls);
+      console.log(`retry: ${10 - retry}`, valid_urls);
     }
 
-    if (pbs_img_urls.length) {
+    if (valid_urls.length) {
       break;
     }
 
@@ -53,5 +74,22 @@ export default async function getTwitterImageUrls(url: string): Promise<string[]
 
   await browser.close();
 
-  return pbs_img_urls;
+  return valid_urls;
 };
+
+if (process.env.NODE_ENV !== 'production') {
+  process.on('uncaughtException', exception => console.log(exception));
+
+  const video_url = 'https://twitter.com/trinityfate62/status/1375130608049954820';
+  // getTwitterImageUrls(video_url);
+
+  const multi_img_url = 'https://twitter.com/sora1013siba/status/1374930115574996996';
+  (async () => {
+    try { await getTwitterImageUrls(multi_img_url); }
+    catch (err) { console.log(err); }
+  })();
+
+  const img_url = 'https://twitter.com/Machiccalition/status/1374828782620565504';
+  // getTwitterImageUrls(img_url);
+
+}


### PR DESCRIPTION
[What] fix crawler selects images from replies

[Why] Only the main post is our target
[How] All the main images are contained inside an anchor tag that
it href to  `{main_post}/photos/[id]`
So update the selector from `img[src]` to `a[href*="/${statusId}/"] img[src]`
limit the img tag matches
 